### PR TITLE
✨ Implement get_award_votings to NBA module

### DIFF
--- a/API.md
+++ b/API.md
@@ -82,6 +82,13 @@ Get all winners of a given award.
 Parameters:
   - **`award`**: Desired award (one of `'mvp'`,`'roy'`,`'dpoy'`,`'smoy'`,`'tmoy'`,`'mip'`,`'citizenship'`,`'finals_mvp'`,`'playoffs_mvp'`,`'wcf_mvp'`,`'ecf_mvp'`,`'all_star_mvp'`,`'cpoy'`,`'player_of_the_seeding_games'`,`'tsn_mvp'`,`'tsn_roy'`,`'hustle'`,`'social_justice'`,`'coy'`,`'nbca_coy'`,`'eoy'`)
 
+### `get_award_votings(award, season)`
+Get all players who received votes for a given award in a given season.
+
+Parameters:
+  - **`award`**: Desired award (one of `'mvp'`,`'roy'`,`'all_nba'`, `'all_defense'`)
+  - **`season`**: Desired season indicated by the ending year (e.g. `2023` for 2022-23 season) Only accept seasons starting from 1977.
+
 
 # G League
 

--- a/BRScraper/nba.py
+++ b/BRScraper/nba.py
@@ -438,3 +438,62 @@ def get_awards(award):
         df = df[(df['Player'].notna())&(df['Player']!='Player')].reset_index(drop=True)
     
     return df
+
+def get_award_votings(award:str, season:int)->pd.DataFrame:
+    """
+    Get award voting data for a given award and season.
+
+    Parameters
+    ----------
+    award : str, optional
+        The award to get voting data for.
+    season : int, optional
+        The season to get voting data for.
+    
+    Returns
+    -------
+    pd.DataFrame
+        A dataframe containing the voting data for the given award and season.
+    """
+    
+    values = [
+        'mvp'
+        ,'roy'
+        ,'all_nba'
+        ,'all_defense'
+    ]
+    
+    # Check if award is valid
+    if award not in values:
+        raise ValueError(str(award)+' is not a valid value. Try one of: "'+'", "'.join(values)+'".')
+    
+    # Check if season is valid
+    if season < 1977:
+        raise ValueError(str(season)+' is not a valid season. Try a value greater or equal than 1977.')
+
+    # Build url
+    url = 'https://www.basketball-reference.com/awards/awards_'+str(season)+'.html'
+
+    # Get the index of the award
+    if award == 'mvp':
+        index = 0
+    elif award == 'roy':
+        index = 1
+    elif award == 'all_nba':
+        index = 2
+    elif award == 'all_defense':
+        index = 3
+    
+    # Read table from url
+    try:
+        df = pd.read_html(url)[index]
+    except Exception as e:
+        raise ValueError(str(season)+' is not a valid season.') from e
+    
+    # Remove multiindex level 0 where str contains Unnamed
+    df.columns  = df.columns.map(lambda x: '_'.join(x) if 'Unnamed' not in x[0] else x[1]).str.strip('_')    
+    
+    # Remove rows where Player is NaN
+    df = df[df['Player'].notna()].reset_index(drop=True)
+
+    return df

--- a/examples_nba.py
+++ b/examples_nba.py
@@ -65,3 +65,7 @@ print(df)
 # Get all MVPs
 df = nba.get_awards('mvp')
 print(df)
+
+# Get MVP votings from 2023
+df = nba.get_award_votings('mvp', 2023)
+print(df)


### PR DESCRIPTION
### What does this PR do?
This pull request adds a new function to the `nba.py` module in the `BRScraper` repository. The function, `get_award_votings`, retrieves award voting data for specific awards and seasons from the basketball-reference website (`https://www.basketball-reference.com/awards/awards_{season}.html`).

The function takes two parameters:
* `award` (the award to retrieve voting data for);
* `season` (the season for which the voting data should be fetched).

The function primarily focuses on retrieving voting data for four major awards:
* Most Valuable Player (MVP);
* Rookie of the Year (ROY);
* All-NBA Team;
* All-Defensive Team.

This is due to the limitation that only these four awards are available in the majority of website's response to `pd.read_html()`.

### Where should the reviewer start?
The reviewer should start by examining the newly added function `get_award_votings` in the `nba.py` module. This function is responsible for fetching award voting data based on the specified award and season from the basketball-reference website. The code contains handling for **valid awards**, **valid seasons**, and also includes **exception handling** for potential errors during data retrieval.

### Testing considerations
1. One important thing to note is that only four specific awards are retrievable through this function: MVP, ROY, All-NBA Team, and All-Defensive Team. The code enforces this limitation by having a predefined list of valid awards and checking if the input `award` matches one of these valid values. As the data tables on the website might change or not include all awards for a specific season due to NBA changes, this constraint ensures that only the available award data is fetched.

2. The `season` parameter has a constraint that only allows values greater than or equal to 1977. This constraint has been added to avoid complications caused by changes in awards and indexes before the 1977 season. This threshold is in place to ensure that the retrieved data corresponds accurately to the specified award and season. Future enhancements could potentially address data retrieval for seasons before 1977.

By following these testing considerations and constraints, the function aims to provide accurate and relevant award voting data from the basketball-reference website (https://www.basketball-reference.com/awards/awards_{season}.html) for the specified award and season.

Your feedback and suggestions for improvements are welcome.